### PR TITLE
Convert iterating approach for sample_size to closed form expression

### DIFF
--- a/fse/models/utils.py
+++ b/fse/models/utils.py
@@ -70,17 +70,18 @@ def compute_principal_components(
         Singular values and singular vectors
     """
     start = time()
+    num_vectors = vectors.shape[0]
     svd = TruncatedSVD(
         n_components=components, n_iter=7, random_state=42, algorithm="randomized"
     )
 
     sample_size = int(1024**3 * cache_size_gb / (vectors.shape[1] * dtype(REAL).itemsize))
 
-    if sample_size > vectors.shape[1]:
+    if sample_size > num_vectors:
         svd.fit(vectors)
     else:
         logger.info(f"sampling {sample_size} vectors to compute principal components")
-        sample_indices = choice(range(vectors.shape[0]), replace=False, size=int(1e6))
+        sample_indices = choice(range(num_vectors), replace=False, size=int(1e6))
         svd.fit(vectors[sample_indices, :])
 
     elapsed = time()

--- a/fse/models/utils.py
+++ b/fse/models/utils.py
@@ -6,7 +6,7 @@
 
 from sklearn.decomposition import TruncatedSVD
 
-from numpy import ndarray, float32 as REAL, ones, vstack, inf as INF, dtype
+from numpy import ndarray, float32 as REAL, ones, vstack, dtype
 from numpy.random import choice
 
 from time import time
@@ -74,21 +74,14 @@ def compute_principal_components(
         n_components=components, n_iter=7, random_state=42, algorithm="randomized"
     )
 
-    current_mem = INF
-    sample_size = len(vectors)
-    while 1:
-        current_mem = sample_size * vectors.shape[1] * dtype(REAL).itemsize / 1024 ** 3
-        if current_mem < cache_size_gb:
-            break
-        sample_size *= 0.995
-    sample_size = int(sample_size)
+    sample_size = int(1024**3 * cache_size_gb / (vectors.shape[1] * dtype(REAL).itemsize))
 
-    if sample_size < len(vectors):
+    if sample_size > vectors.shape[1]:
+        svd.fit(vectors)
+    else:
         logger.info(f"sampling {sample_size} vectors to compute principal components")
         sample_indices = choice(range(vectors.shape[0]), replace=False, size=int(1e6))
-        svd.fit(vstack([vectors[i] for i in sample_indices]))
-    else:
-        svd.fit(vectors)
+        svd.fit(vectors[sample_indices, :])
 
     elapsed = time()
     logger.info(


### PR DESCRIPTION
I thought it would be easier to understand the code to get the `sample_size` if the code just used an algebraic expression instead of the iteration based approach. Plus the closed-form expression should be more efficient.

I also updated `vstack([vectors[i] for i in sample_indices])` to just use a logical index from the sample indices instead: `vectors[sample_indices, :]`. I think it's a little cleaner, but it really comes down to personal choice. 🤷‍♂️ 