### PR TITLE
Lock gensim dependency below 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ INSTALL_REQUIRES = [
     "scipy >= 0.18.1",
     "smart_open >= 1.5.0",
     "scikit-learn >= 0.19.1",
-    "gensim >= 3.8.0",
+    "gensim >= 3.8.0, < 4.0",
     "wordfreq >= 2.2.1",
     "psutil",
 ]


### PR DESCRIPTION
gensim 4.0 was recently released and since fse doesn't have an upper bound on gensim version (and other dependencies as well), fresh installation will break due to gensim API changes.