### PR TITLE
FSE migration to Gensim >=4

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ gensim.models.keyedvectors.BaseKeyedVectors class, for example *Word2Vec* or *Fa
 ```
 from gensim.models import FastText
 sentences = [["cat", "say", "meow"], ["dog", "say", "woof"]]
-ft = FastText(sentences, min_count=1, size=10)
+ft = FastText(sentences, min_count=1, vector_size=10)
 
 from fse import Average, IndexedList
 model = Average(ft)

--- a/fse/models/average.py
+++ b/fse/models/average.py
@@ -151,7 +151,7 @@ def train_average_np(
                     word_index = model.wv.key_to_index[word]
                     mem += w_vectors[word_index] * w_weights[word_index]
                 else:
-                    ngram_hashes = ft_ngram_hashes(word, min_n, max_n, bucket, True)[
+                    ngram_hashes = ft_ngram_hashes(word, min_n, max_n, bucket)[
                         :max_ngrams
                     ]
                     if len(ngram_hashes) == 0:

--- a/fse/models/average.py
+++ b/fse/models/average.py
@@ -18,14 +18,14 @@ Initialize and train a :class:`~fse.models.sentence2vec.Sentence2Vec` model
 
 .. sourcecode:: pycon
 
-        >>> from gensim.models.word2vec import Word2Vec
-        >>> sentences = [["cat", "say", "meow"], ["dog", "say", "woof"]]
-        >>> model = Word2Vec(sentences, min_count=1, size=20)
-
-        >>> from fse.models.average import Average        
-        >>> avg = Average(model)
-        >>> avg.train([(s, i) for i, s in enumerate(sentences)])
-        >>> avg.sv.vectors.shape
+        # >>> from gensim.models.word2vec import Word2Vec
+        # >>> sentences = [["cat", "say", "meow"], ["dog", "say", "woof"]]
+        # >>> model = Word2Vec(sentences, min_count=1, vector_size=20)
+        #
+        # >>> from fse.models.average import Average
+        # >>> avg = Average(model)
+        # >>> avg.train([(s, i) for i, s in enumerate(sentences)])
+        # >>> avg.sv.vectors.shape
         (2, 20)
 
 """
@@ -34,8 +34,8 @@ from __future__ import division
 
 from fse.models.base_s2v import BaseSentence2VecModel
 
-from gensim.models.keyedvectors import BaseKeyedVectors
-from gensim.models.utils_any2vec import ft_ngram_hashes
+from gensim.models.keyedvectors import KeyedVectors
+from gensim.models.fasttext import ft_ngram_hashes
 
 from numpy import (
     ndarray,
@@ -88,7 +88,7 @@ def train_average_np(
 
     """
     size = model.wv.vector_size
-    vocab = model.wv.vocab
+    # vocab = model.wv.vocab
 
     w_vectors = model.wv.vectors
     w_weights = model.word_weights
@@ -121,7 +121,7 @@ def train_average_np(
             sent = obj[0]
             sent_adr = obj[1]
 
-            word_indices = [vocab[word].index for word in sent if word in vocab]
+            word_indices = [model.wv.key_to_index[word] for word in sent if word in model.wv.key_to_index]
             eff_sentences += 1
             if not len(word_indices):
                 continue
@@ -147,8 +147,8 @@ def train_average_np(
             eff_words += len(sent)  # Counts everything in the sentence
 
             for word in sent:
-                if word in vocab:
-                    word_index = vocab[word].index
+                if word in model.wv.key_to_index:
+                    word_index = model.wv.key_to_index[word]
                     mem += w_vectors[word_index] * w_weights[word_index]
                 else:
                     ngram_hashes = ft_ngram_hashes(word, min_n, max_n, bucket, True)[
@@ -191,7 +191,7 @@ class Average(BaseSentence2VecModel):
 
     Attributes
     ----------
-    wv : :class:`~gensim.models.keyedvectors.BaseKeyedVectors`
+    wv : :class:`~gensim.models.keyedvectors.KeyedVectors`
         This object essentially contains the mapping between words and embeddings. After training, it can be used
         directly to query those embeddings in various ways. See the module level docstring for examples.
 
@@ -207,7 +207,7 @@ class Average(BaseSentence2VecModel):
 
     def __init__(
         self,
-        model: BaseKeyedVectors,
+        model: KeyedVectors,
         sv_mapfile_path: str = None,
         wv_mapfile_path: str = None,
         workers: int = 1,
@@ -222,7 +222,7 @@ class Average(BaseSentence2VecModel):
 
         Parameters
         ----------
-        model : :class:`~gensim.models.keyedvectors.BaseKeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
+        model : :class:`~gensim.models.keyedvectors.KeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
             This object essentially contains the mapping between words and embeddings. To compute the sentence embeddings
             the wv.vocab and wv.vector elements are required.
         sv_mapfile_path : str, optional

--- a/fse/models/base_s2v.py
+++ b/fse/models/base_s2v.py
@@ -56,6 +56,7 @@ from numpy import (
     ones,
     finfo,
     full,
+    linalg
 )
 
 from wordfreq import available_languages, get_frequency_dict
@@ -315,7 +316,7 @@ class BaseSentence2VecModel(SaveLoad):
                 "you must initialize vectors_vocab before computing sentence vectors"
             )
 
-        if sum([self.wv.get_vecattr(w, "count") for w in self.wv.key_to_index.__dict__.keys()]) == len(self.wv):
+        if sum([self.wv.get_vecattr(w, "count") for w in self.wv.key_to_index]) == len(self.wv):
             logger.warning(
                 "The sum of the word counts is equal to its length (all word counts are 1). "
                 "Make sure to obtain proper word counts by using lang_freq for pretrained embeddings."
@@ -806,7 +807,7 @@ class BaseSentence2VecModel(SaveLoad):
         self._post_inference_calls(output=output)
 
         if use_norm:
-            output = Nmf.l2_norm(output)
+            output /= linalg.norm(output, axis=1)
         return output
 
     def _train_manager(

--- a/fse/models/base_s2v.py
+++ b/fse/models/base_s2v.py
@@ -11,7 +11,7 @@ for the outstanding library which I used for a lot of my research.
 
 Attributes
 ----------
-wv : :class:`~gensim.models.keyedvectors.BaseKeyedVectors`
+wv : :class:`~gensim.models.keyedvectors.KeyedVectors`
     This object essentially contains the mapping between words and embeddings. After training, it can be used
     directly to query those embeddings in various ways. See the module level docstring for examples.
 
@@ -38,8 +38,9 @@ from fse.models.sentencevectors import SentenceVectors
 
 from fse.models.utils import set_madvise_for_mmap
 
-from gensim.models.base_any2vec import BaseWordEmbeddingsModel
-from gensim.models.keyedvectors import BaseKeyedVectors, FastTextKeyedVectors, _l2_norm
+from gensim.models.word2vec import Word2Vec
+from gensim.models.keyedvectors import KeyedVectors
+from gensim.models.nmf import Nmf
 from gensim.utils import SaveLoad
 from gensim.matutils import zeros_aligned
 
@@ -81,7 +82,7 @@ EPS = finfo(REAL).eps
 class BaseSentence2VecModel(SaveLoad):
     def __init__(
         self,
-        model: BaseKeyedVectors,
+        model: KeyedVectors,
         sv_mapfile_path: str = None,
         wv_mapfile_path: str = None,
         workers: int = 1,
@@ -96,7 +97,7 @@ class BaseSentence2VecModel(SaveLoad):
 
         Parameters
         ----------
-        model : :class:`~gensim.models.keyedvectors.BaseKeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
+        model : :class:`~gensim.models.keyedvectors.KeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
             This object essentially contains the mapping between words and embeddings. To compute the sentence embeddings
             the wv.vocab and wv.vector elements are required.
         sv_mapfile_path : str, optional
@@ -157,7 +158,7 @@ class BaseSentence2VecModel(SaveLoad):
         )
         self.prep = BaseSentence2VecPreparer()
 
-        self.word_weights = ones(len(self.wv.vocab), REAL)
+        self.word_weights = ones(len(self.wv), REAL)
 
     def __str__(self) -> str:
         """Human readable representation of the model's state.
@@ -170,26 +171,26 @@ class BaseSentence2VecModel(SaveLoad):
         """
         return f"{self.__class__.__name__} based on {self.wv.__class__.__name__}, size={len(self.sv)}"
 
-    def _check_and_include_model(self, model: BaseKeyedVectors):
+    def _check_and_include_model(self, model: KeyedVectors):
         """Check if the supplied model is a compatible model. Performs all kinds of checks and small optimizations.
 
         Parameters
         ----------
-        model : :class:`~gensim.models.keyedvectors.BaseKeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
+        model : :class:`~gensim.models.keyedvectors.KeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
             The model to inject into this class.
 
         """
-        if isinstance(model, BaseWordEmbeddingsModel):
+        if isinstance(model, Word2Vec):
             self.wv = model.wv
-        elif isinstance(model, BaseKeyedVectors):
+        elif isinstance(model, KeyedVectors):
             self.wv = model
         else:
             raise RuntimeError(
-                f"Model must be child of BaseWordEmbeddingsModel or BaseKeyedVectors. Received {str(model)}"
+                f"Model must be child of BaseWordEmbeddingsModel or KeyedVectors. Received {str(model)}"
             )
         self.wv.vectors_norm = None
 
-        if isinstance(self.wv, FastTextKeyedVectors):
+        if isinstance(self.wv, KeyedVectors):
             self.wv.vectors_vocab_norm = None  # Save some space
             self.wv.vectors_ngrams_norm = None
             self.wv.vectors_vocab_norm = None
@@ -210,8 +211,8 @@ class BaseSentence2VecModel(SaveLoad):
             raise RuntimeError(
                 "Word vectors required for sentence embeddings not found."
             )
-        if not hasattr(self.wv, "vocab"):
-            raise RuntimeError("Vocab required for sentence embeddings not found.")
+        # if not hasattr(self.wv, "vocab"):
+        #     raise RuntimeError("Vocab required for sentence embeddings not found.")
 
     def _check_language_settings(self, lang_freq: str):
         """Check if the supplied language is a compatible with the wordfreq package
@@ -243,9 +244,9 @@ class BaseSentence2VecModel(SaveLoad):
         freq_dict = get_frequency_dict(self.lang_freq, wordlist="best")
         for word in self.wv.index2word:
             if word in freq_dict:
-                self.wv.vocab[word].count = int(freq_dict[word] * domain)
+                self.wv.set_vecattr(word, "count", int(freq_dict[word] * domain))
             else:
-                self.wv.vocab[word].count = int(1e-8 * domain)
+                self.wv.set_vecattr(word, "count", int(1e-8 * domain))
 
     def _check_input_data_sanity(self, data_iterable: tuple):
         """Check if the input data complies with the required formats
@@ -299,7 +300,7 @@ class BaseSentence2VecModel(SaveLoad):
 
         """
         if not hasattr(self, "wv") or self.wv is None:
-            raise RuntimeError("you must first load a valid BaseKeyedVectors object")
+            raise RuntimeError("you must first load a valid KeyedVectors object")
         if not len(self.wv.vectors):
             raise RuntimeError(
                 "you must initialize vectors before computing sentence vectors"
@@ -314,7 +315,7 @@ class BaseSentence2VecModel(SaveLoad):
                 "you must initialize vectors_vocab before computing sentence vectors"
             )
 
-        if sum([self.wv.vocab[w].count for w in self.wv.vocab]) == len(self.wv.vocab):
+        if sum([self.wv.get_vecattr(w, "count") for w in self.wv.key_to_index.__dict__.keys()]) == len(self.wv):
             logger.warning(
                 "The sum of the word counts is equal to its length (all word counts are 1). "
                 "Make sure to obtain proper word counts by using lang_freq for pretrained embeddings."
@@ -805,7 +806,7 @@ class BaseSentence2VecModel(SaveLoad):
         self._post_inference_calls(output=output)
 
         if use_norm:
-            output = _l2_norm(output)
+            output = Nmf.l2_norm(output)
         return output
 
     def _train_manager(

--- a/fse/models/sentencevectors.py
+++ b/fse/models/sentencevectors.py
@@ -11,7 +11,7 @@ from fse.inputs import IndexedList, IndexedLineDocument
 
 from fse.models.utils import set_madvise_for_mmap
 
-from gensim.models.keyedvectors import BaseKeyedVectors
+from gensim.models.keyedvectors import KeyedVectors
 
 from numpy import (
     dot,
@@ -328,7 +328,7 @@ class SentenceVectors(utils.SaveLoad):
     def similar_by_word(
         self,
         word: str,
-        wv: BaseKeyedVectors,
+        wv: KeyedVectors,
         indexable: Union[IndexedList, IndexedLineDocument] = None,
         topn: int = 10,
         restrict_size: Union[int, Tuple[int, int]] = None,
@@ -340,7 +340,7 @@ class SentenceVectors(utils.SaveLoad):
         ----------
         word : str
             Word
-        wv : :class:`~gensim.models.keyedvectors.BaseKeyedVectors`
+        wv : :class:`~gensim.models.keyedvectors.KeyedVectors`
             This object essentially contains the mapping between words and embeddings.
         indexable: list, IndexedList, IndexedLineDocument
             Provides an indexable object from where the most similar sentences are read

--- a/fse/models/sif.py
+++ b/fse/models/sif.py
@@ -7,7 +7,7 @@
 from fse.models.average import Average
 from fse.models.utils import compute_principal_components, remove_principal_components
 
-from gensim.models.keyedvectors import BaseKeyedVectors
+from gensim.models.keyedvectors import KeyedVectors
 
 from numpy import ndarray, float32 as REAL, zeros, isfinite
 
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 class SIF(Average):
     def __init__(
         self,
-        model: BaseKeyedVectors,
+        model: KeyedVectors,
         alpha: float = 1e-3,
         components: int = 1,
         cache_size_gb: float = 1.0,
@@ -36,7 +36,7 @@ class SIF(Average):
 
         Parameters
         ----------
-        model : :class:`~gensim.models.keyedvectors.BaseKeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
+        model : :class:`~gensim.models.keyedvectors.KeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
             This object essentially contains the mapping between words and embeddings. To compute the sentence embeddings
             the wv.vocab and wv.vector elements are required.
         alpha : float, optional
@@ -133,15 +133,15 @@ class SIF(Average):
 
     def _compute_sif_weights(self):
         """ Precomputes the SIF weights for all words in the vocabulary """
-        logger.info(f"pre-computing SIF weights for {len(self.wv.vocab)} words")
-        v = len(self.wv.vocab)
+        logger.info(f"pre-computing SIF weights for {len(self.wv)} words")
+        v = len(self.wv)
         corpus_size = 0
 
         pw = zeros(v, dtype=REAL)
-        for word in self.wv.vocab:
-            c = self.wv.vocab[word].count
+        for word in self.wv.key_to_index.__dict__.keys():
+            c = self.wv.get_vecattr(word, "count")
             corpus_size += c
-            pw[self.wv.vocab[word].index] = c
+            pw[self.wv.key_to_index[word]] = c
         pw /= corpus_size
 
         self.word_weights = (self.alpha / (self.alpha + pw)).astype(REAL)

--- a/fse/models/sif.py
+++ b/fse/models/sif.py
@@ -138,7 +138,7 @@ class SIF(Average):
         corpus_size = 0
 
         pw = zeros(v, dtype=REAL)
-        for word in self.wv.key_to_index.__dict__.keys():
+        for word in self.wv.key_to_index:
             c = self.wv.get_vecattr(word, "count")
             corpus_size += c
             pw[self.wv.key_to_index[word]] = c

--- a/fse/models/usif.py
+++ b/fse/models/usif.py
@@ -6,7 +6,7 @@
 
 import logging
 
-from gensim.models.keyedvectors import BaseKeyedVectors
+from gensim.models.keyedvectors import KeyedVectors
 from numpy import float32 as REAL
 from numpy import isfinite, ndarray, zeros
 
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 class uSIF(Average):
     def __init__(
         self,
-        model: BaseKeyedVectors,
+        model: KeyedVectors,
         length: int = None,
         components: int = 5,
         cache_size_gb: float = 1.0,
@@ -41,7 +41,7 @@ class uSIF(Average):
 
         Parameters
         ----------
-        model : :class:`~gensim.models.keyedvectors.BaseKeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
+        model : :class:`~gensim.models.keyedvectors.KeyedVectors` or :class:`~gensim.models.base_any2vec.BaseWordEmbeddingsModel`
             This object essentially contains the mapping between words and embeddings. To compute the sentence embeddings
             the wv.vocab and wv.vector elements are required.
         length : int, optional
@@ -153,15 +153,15 @@ class uSIF(Average):
 
     def _compute_usif_weights(self):
         """Precomputes the uSIF weights."""
-        logger.info(f"pre-computing uSIF weights for {len(self.wv.vocab)} words")
-        v = len(self.wv.vocab)
+        logger.info(f"pre-computing uSIF weights for {len(self.wv)} words")
+        v = len(self.wv)
         corpus_size = 0
 
         pw = zeros(v, dtype=REAL)
-        for word in self.wv.vocab:
-            c = self.wv.vocab[word].count
+        for word in self.wv.key_to_index.__dict__.keys():
+            c = self.wv.get_vecattr(word, "count")
             corpus_size += c
-            pw[self.wv.vocab[word].index] = c
+            pw[self.wv.key_to_index[word]] = c
         pw /= corpus_size
 
         threshold = 1 - (1 - (1 / v)) ** self.length

--- a/fse/models/usif.py
+++ b/fse/models/usif.py
@@ -158,7 +158,7 @@ class uSIF(Average):
         corpus_size = 0
 
         pw = zeros(v, dtype=REAL)
-        for word in self.wv.key_to_index.__dict__.keys():
+        for word in self.wv.key_to_index:
             c = self.wv.get_vecattr(word, "count")
             corpus_size += c
             pw[self.wv.key_to_index[word]] = c

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ INSTALL_REQUIRES = [
     "scipy >= 0.18.1",
     "smart_open >= 1.5.0",
     "scikit-learn >= 0.19.1",
-    "gensim<4",
+    "gensim >= 4",
     "wordfreq >= 2.2.1",
     "huggingface-hub",
     "psutil",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
 NAME = "fse"
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 DESCRIPTION = "Fast Sentence Embeddings for Gensim"
 AUTHOR = "Oliver Borchers"
 AUTHOR_EMAIL = "o.borchers@oxolo.com"

--- a/test/test_average.py
+++ b/test/test_average.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 TEST_DATA = Path(__file__).parent / "test_data"
 CORPUS = TEST_DATA / "test_sentences.txt"
 DIM = 5
-W2V = Word2Vec(min_count=1, size=DIM)
+W2V = Word2Vec(min_count=1, vector_size=DIM)
 with open(CORPUS, "r") as file:
     SENTENCES = [l.split() for _, l in enumerate(file)]
 W2V.build_vocab(SENTENCES)
@@ -66,7 +66,7 @@ class TestAverageFunctions(unittest.TestCase):
         self.assertEqual((4, 7), output)
         self.assertTrue((183 == self.model.sv[0]).all())
         self.assertTrue((164.5 == self.model.sv[1]).all())
-        self.assertTrue((self.model.wv.vocab["go"].index == self.model.sv[2]).all())
+        self.assertTrue((self.model.wv.key_to_index["go"] == self.model.sv[2]).all())
 
     def test_average_train_cy_w2v(self):
         self.model.sv.vectors = np.zeros_like(self.model.sv.vectors, dtype=np.float32)
@@ -80,10 +80,10 @@ class TestAverageFunctions(unittest.TestCase):
         self.assertEqual((4, 7), output)
         self.assertTrue((183 == self.model.sv[0]).all())
         self.assertTrue((164.5 == self.model.sv[1]).all())
-        self.assertTrue((self.model.wv.vocab["go"].index == self.model.sv[2]).all())
+        self.assertTrue((self.model.wv.key_to_index["go"] == self.model.sv[2]).all())
 
     def test_average_train_np_ft(self):
-        ft = FastText(min_count=1, size=DIM)
+        ft = FastText(min_count=1, vector_size=DIM)
         ft.build_vocab(SENTENCES)
         m = Average(ft)
         m.prep.prepare_vectors(
@@ -103,7 +103,7 @@ class TestAverageFunctions(unittest.TestCase):
         # (2 + 1) / 2 = 1.5
 
     def test_average_train_cy_ft(self):
-        ft = FastText(min_count=1, size=DIM)
+        ft = FastText(min_count=1, vector_size=DIM)
         ft.build_vocab(SENTENCES)
         m = Average(ft)
         m.prep.prepare_vectors(
@@ -146,7 +146,7 @@ class TestAverageFunctions(unittest.TestCase):
         self.assertTrue((m1.sv.vectors == m2.sv.vectors).all())
 
     def test_cy_equal_np_w2v_random(self):
-        w2v = Word2Vec(min_count=1, size=DIM)
+        w2v = Word2Vec(min_count=1, vector_size=DIM)
         # Random initialization
         w2v.build_vocab(SENTENCES)
 
@@ -172,7 +172,7 @@ class TestAverageFunctions(unittest.TestCase):
         self.assertTrue(np.allclose(m1.sv.vectors, m2.sv.vectors, atol=1e-6))
 
     def test_cy_equal_np_ft_random(self):
-        ft = FastText(size=20, min_count=1)
+        ft = FastText(vector_size=20, min_count=1)
         ft.build_vocab(SENTENCES)
 
         m1 = Average(ft)

--- a/test/test_base_s2v.py
+++ b/test/test_base_s2v.py
@@ -333,7 +333,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
 
-        for v in se.wv.key_to_index.__dict__.keys():
+        for v in se.wv.key_to_index:
             se.wv.set_vecattr(v, "count", 1)
 
         # Just throws multiple warnings warning

--- a/test/test_base_s2v.py
+++ b/test/test_base_s2v.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 TEST_DATA = Path(__file__).parent / "test_data"
 CORPUS = TEST_DATA / "test_sentences.txt"
 DIM = 5
-W2V = Word2Vec(min_count=1, size=DIM)
+W2V = Word2Vec(min_count=1, vector_size=DIM)
 with open(CORPUS, "r") as file:
     SENTENCES = [l.split() for _, l in enumerate(file)]
 W2V.build_vocab(SENTENCES)
@@ -42,11 +42,11 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
     def test_init_w_empty_vocab_model(self):
         with self.assertRaises(RuntimeError):
             w2v = Word2Vec()
-            del w2v.wv.vocab
+            del w2v.wv
             BaseSentence2VecModel(w2v)
 
     def test_init_w_ft_model_wo_vecs(self):
-        ft = FastText(SENTENCES, size=5)
+        ft = FastText(SENTENCES, vector_size=5)
         with self.assertRaises(RuntimeError):
             ft.wv.vectors_vocab = None
             BaseSentence2VecModel(ft)
@@ -55,14 +55,14 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
             BaseSentence2VecModel(ft)
 
     def test_init_w_empty_ft_model(self):
-        ft = FastText(min_count=1, size=DIM)
+        ft = FastText(min_count=1, vector_size=DIM)
         ft.wv.vectors = np.zeros(10)
         ft.wv.vectors_ngrams = None
         with self.assertRaises(RuntimeError):
             BaseSentence2VecModel(ft)
 
     def test_init_w_incompatible_ft_model(self):
-        ft = FastText(min_count=1, size=DIM, compatible_hash=False)
+        ft = FastText(min_count=1, vector_size=DIM, compatible_hash=False)
         with self.assertRaises(RuntimeError):
             BaseSentence2VecModel(ft)
 
@@ -73,8 +73,8 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
     def test_model_w_language(self):
         se = BaseSentence2VecModel(W2V, lang_freq="en")
         freq = int((2 ** 31 - 1) * get_frequency_dict("en", wordlist="best")["help"])
-        self.assertEqual(freq, se.wv.vocab["help"].count)
-        self.assertEqual(21, se.wv.vocab["79"].count)
+        self.assertEqual(freq, se.wv.get_vecattr("help", "count"))
+        self.assertEqual(21, se.wv.get_vecattr("79", "count"))
 
     def test_model_w_wrong_language(self):
         with self.assertRaises(ValueError):
@@ -87,12 +87,12 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
         self.assertTrue(p.exists())
         se2 = BaseSentence2VecModel.load(str(p.absolute()))
         self.assertTrue((se.wv.vectors == se2.wv.vectors).all())
-        self.assertEqual(se.wv.index2word, se2.wv.index2word)
+        self.assertEqual(se.wv.index_to_key, se2.wv.index_to_key)
         self.assertEqual(se.workers, se2.workers)
         p.unlink()
 
     def test_save_load_with_memmap(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         shape = (1000, 1000)
         ft.wv.vectors = np.zeros(shape, np.float32)
@@ -122,7 +122,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
             p.unlink()
 
     def test_map_all_vectors_to_disk(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
 
         p = TEST_DATA / "test_emb"
@@ -216,7 +216,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
         self.assertEqual(1, output)
 
     def test_estimate_memory(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
         self.assertEqual(2040025124, se.estimate_memory(int(1e8))["Total"])
@@ -247,7 +247,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
             se._post_inference_calls()
 
     def test_check_pre_train_san_no_wv(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
         se.wv = None
@@ -255,7 +255,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
             se._check_pre_training_sanity(1, 1, 1)
 
     def test_check_pre_train_san_no_wv_len(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
         se.wv.vectors = []
@@ -263,7 +263,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
             se._check_pre_training_sanity(1, 1, 1)
 
     def test_check_pre_train_san_no_ngrams_vectors(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
         se.wv.vectors_ngrams = []
@@ -275,7 +275,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
             se._check_pre_training_sanity(1, 1, 1)
 
     def test_check_pre_train_san_no_sv_vecs(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
         se.sv.vectors = None
@@ -283,7 +283,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
             se._check_pre_training_sanity(1, 1, 1)
 
     def test_check_pre_train_san_no_word_weights(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
         se.word_weights = None
@@ -291,7 +291,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
             se._check_pre_training_sanity(1, 1, 1)
 
     def test_check_pre_train_san_incos_len(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
         se.word_weights = np.ones(20)
@@ -299,42 +299,42 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
             se._check_pre_training_sanity(1, 1, 1)
 
     def test_check_pre_train_dtypes(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
 
-        se.wv.vectors = np.zeros((len(se.wv.vocab), 20), dtype=np.float64)
+        se.wv.vectors = np.zeros((len(se.wv), 20), dtype=np.float64)
         with self.assertRaises(TypeError):
             se._check_pre_training_sanity(1, 1, 1)
-        se.wv.vectors = np.zeros((len(se.wv.vocab), 20), dtype=np.float32)
+        se.wv.vectors = np.zeros((len(se.wv), 20), dtype=np.float32)
 
-        se.wv.vectors_ngrams = np.ones(len(se.wv.vocab), dtype=np.float16)
+        se.wv.vectors_ngrams = np.ones(len(se.wv), dtype=np.float16)
         with self.assertRaises(TypeError):
             se._check_pre_training_sanity(1, 1, 1)
-        se.wv.vectors_ngrams = np.ones(len(se.wv.vocab), dtype=np.float32)
+        se.wv.vectors_ngrams = np.ones(len(se.wv), dtype=np.float32)
 
-        se.wv.vectors_vocab = np.ones(len(se.wv.vocab), dtype=np.float16)
+        se.wv.vectors_vocab = np.ones(len(se.wv), dtype=np.float16)
         with self.assertRaises(TypeError):
             se._check_pre_training_sanity(1, 1, 1)
-        se.wv.vectors_vocab = np.ones(len(se.wv.vocab), dtype=np.float32)
+        se.wv.vectors_vocab = np.ones(len(se.wv), dtype=np.float32)
 
-        se.sv.vectors = np.zeros((len(se.wv.vocab), 20), dtype=int)
+        se.sv.vectors = np.zeros((len(se.wv), 20), dtype=int)
         with self.assertRaises(TypeError):
             se._check_pre_training_sanity(1, 1, 1)
-        se.sv.vectors = np.zeros((len(se.wv.vocab), 20), dtype=np.float32)
+        se.sv.vectors = np.zeros((len(se.wv), 20), dtype=np.float32)
 
-        se.word_weights = np.ones(len(se.wv.vocab), dtype=bool)
+        se.word_weights = np.ones(len(se.wv), dtype=bool)
         with self.assertRaises(TypeError):
             se._check_pre_training_sanity(1, 1, 1)
-        se.word_weights = np.ones(len(se.wv.vocab), dtype=np.float32)
+        se.word_weights = np.ones(len(se.wv), dtype=np.float32)
 
     def test_check_pre_train_statistics(self):
-        ft = FastText(min_count=1, size=5)
+        ft = FastText(min_count=1, vector_size=5)
         ft.build_vocab(SENTENCES)
         se = BaseSentence2VecModel(ft)
 
-        for v in se.wv.vocab:
-            se.wv.vocab[v].count = 1
+        for v in se.wv.key_to_index.__dict__.keys():
+            se.wv.set_vecattr(v, "count", 1)
 
         # Just throws multiple warnings warning
         se._check_pre_training_sanity(1, 1, 1)
@@ -379,7 +379,7 @@ class TestBaseSentence2VecModelFunctions(unittest.TestCase):
         p_target.unlink()
 
     def test_move_ft_vectors_to_disk_from_init(self):
-        ft = FastText(min_count=1, size=DIM)
+        ft = FastText(min_count=1, vector_size=DIM)
         ft.build_vocab(SENTENCES)
 
         p = TEST_DATA / "test_vecs"

--- a/test/test_sentencevectors.py
+++ b/test/test_sentencevectors.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 TEST_DATA = Path(__file__).parent / "test_data"
 CORPUS = TEST_DATA / "test_sentences.txt"
 DIM = 5
-W2V = Word2Vec(min_count=1, size=DIM, seed=42)
+W2V = Word2Vec(min_count=1, vector_size=DIM, seed=42)
 with open(CORPUS, "r") as file:
     SENTENCES = [l.split() for _, l in enumerate(file)]
 W2V.build_vocab(SENTENCES)

--- a/test/test_sif.py
+++ b/test/test_sif.py
@@ -124,7 +124,7 @@ class TestSIFFunctions(unittest.TestCase):
         w2v = Word2Vec(min_count=1, vector_size=DIM)
         with open(CORPUS, "r") as file:
             w2v.build_vocab([l.split() for l in file])
-        for k in w2v.wv.key_to_index.__dict__.keys():
+        for k in w2v.wv.key_to_index:
             w2v.wv.set_vecattr(k, "count", np.nan)
 
         model = SIF(w2v)

--- a/test/test_sif.py
+++ b/test/test_sif.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 TEST_DATA = Path(__file__).parent / "test_data"
 CORPUS = TEST_DATA / "test_sentences.txt"
 DIM = 50
-W2V = Word2Vec(min_count=1, size=DIM)
+W2V = Word2Vec(min_count=1, vector_size=DIM)
 with open(CORPUS, "r") as file:
     SENTENCES = [l.split() for _, l in enumerate(file)]
 W2V.build_vocab(SENTENCES)
@@ -98,7 +98,7 @@ class TestSIFFunctions(unittest.TestCase):
         alpha = self.model.alpha
         sif = alpha / (alpha + pw)
 
-        idx = self.model.wv.vocab[w].index
+        idx = self.model.wv.key_to_index[w]
         self.model._compute_sif_weights()
         self.assertTrue(np.allclose(self.model.word_weights[idx], sif))
 
@@ -121,11 +121,11 @@ class TestSIFFunctions(unittest.TestCase):
         model.sv.similar_by_sentence("test sentence".split(), model=model)
 
     def test_broken_vocab(self):
-        w2v = Word2Vec(min_count=1, size=DIM)
+        w2v = Word2Vec(min_count=1, vector_size=DIM)
         with open(CORPUS, "r") as file:
             w2v.build_vocab([l.split() for l in file])
-        for k in w2v.wv.vocab:
-            w2v.wv.vocab[k].count = np.nan
+        for k in w2v.wv.key_to_index.__dict__.keys():
+            w2v.wv.set_vecattr(k, "count", np.nan)
 
         model = SIF(w2v)
         with self.assertRaises(RuntimeError):

--- a/test/test_usif.py
+++ b/test/test_usif.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 CORPUS = Path(__file__).parent / "test_data" / "test_sentences.txt"
 DIM = 50
-W2V = Word2Vec(min_count=1, size=DIM)
+W2V = Word2Vec(min_count=1, vector_vector_size=DIM)
 with open(CORPUS, "r") as file:
     SENTENCES = [l.split() for _, l in enumerate(file)]
 W2V.build_vocab(SENTENCES)
@@ -92,7 +92,7 @@ class TestuSIFFunctions(unittest.TestCase):
     def test_compute_usif_weights(self):
         w = "Good"
         pw = 1.916650481770269e-08
-        idx = self.model.wv.vocab[w].index
+        idx = self.model.wv.key_to_index[w]
         self.model.length = 11
         a = 0.17831555484795414
         usif = a / ((a / 2) + pw)
@@ -105,12 +105,12 @@ class TestuSIFFunctions(unittest.TestCase):
         self.assertTrue(np.isfinite(self.model.sv.vectors).all())
 
     def test_broken_vocab(self):
-        w2v = Word2Vec(min_count=1, size=DIM)
+        w2v = Word2Vec(min_count=1, vector_vector_size=DIM)
 
         with open(CORPUS, "r") as file:
             w2v.build_vocab([l.split() for l in file])
-        for k in w2v.wv.vocab:
-            w2v.wv.vocab[k].count = np.nan
+        for k in w2v.wv.key_to_index.__dict__.keys():
+            w2v.wv.set_vecattr(k, "count", np.nan)
 
         model = uSIF(w2v)
 

--- a/test/test_usif.py
+++ b/test/test_usif.py
@@ -109,7 +109,7 @@ class TestuSIFFunctions(unittest.TestCase):
 
         with open(CORPUS, "r") as file:
             w2v.build_vocab([l.split() for l in file])
-        for k in w2v.wv.key_to_index.__dict__.keys():
+        for k in w2v.wv.key_to_index:
             w2v.wv.set_vecattr(k, "count", np.nan)
 
         model = uSIF(w2v)


### PR DESCRIPTION
I needed FSE with Gensim >=4 but I was unable to use it due to API compatibility bugs, as discussed in #40 and #43 .
I successfully performed the migration and tested it with success with a KNN classification task.