### PR TITLE
Avoid crushing due to AttributeError during poetry install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,6 @@ class CustomBuildExt(build_ext):
         build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process:
         # https://docs.python.org/2/library/__builtin__.html#module-__builtin__
-        __builtins__.__NUMPY_SETUP__ = False
 
         import numpy
 

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,11 @@ class CustomBuildExt(build_ext):
         # Prevent numpy from thinking it is still in its setup process:
         # https://docs.python.org/2/library/__builtin__.html#module-__builtin__
 
+        try:
+            __builtins__.__NUMPY_SETUP__ = False
+        except AttributeError:
+            pass
+
         import numpy
 
         self.include_dirs.append(numpy.get_include())


### PR DESCRIPTION
The hack around numpy during installation  with poetry throws an attribute error due to the lack of the attribute during.

```
    Preparing metadata (pyproject.toml): finished with status 'error'
    error: subprocess-exited-with-error
    
    × Preparing metadata (pyproject.toml) did not run successfully.

```
(...)

```
    AttributeError: 'dict' object has no attribute '__NUMPY_SETUP__'
```

This is due to the hack to prevent numpy to prevent it is still in its setup process.

IMHO, this has been fixed in gensim 4.3.0 and It is not causing problems anymore so it is not needed.

I added a try/except in order to let the installation continue in case it is not found




